### PR TITLE
Fix google api key placeholder for example

### DIFF
--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -9,8 +9,8 @@
         android:name="io.flutter.app.FlutterApplication"
         android:label="easy_google_maps_example"
         android:icon="@mipmap/ic_launcher">
-         <meta-data android:name="com.google.android.geo.YOUR_API_KEY_HERE"
-               android:value="YOUR KEY HERE"/>
+         <meta-data android:name="com.google.android.geo.API_KEY"
+               android:value="YOUR_API_KEY_HERE"/>
         <activity
             android:name=".MainActivity"
             android:launchMode="singleTop"


### PR DESCRIPTION
1. Google API key not found although change this below line,
```
<meta-data android:name="com.google.android.geo.YOUR_API_KEY_HERE"
               android:value="Alxxxxxxxxxxxxxxxxxxxxxx"/>
```

2. From this google map documentation (https://developers.google.com/maps/documentation/android-sdk/get-api-key), the code should be like this:
```
com.google.android.geo.API_KEY
```

3. To avoid confusion, rename the Google API key placeholder.
```
<meta-data android:name="com.google.android.geo.API_KEY"
               android:value="YOUR_API_KEY_HERE"/>
```

